### PR TITLE
Add FrameSizeDeterminationPass

### DIFF
--- a/src/casmd.cpp
+++ b/src/casmd.cpp
@@ -396,6 +396,7 @@ class LanguageServer final : public ServerInterface
         pm.add< libcasm_fe::TypeCheckPass >();
         pm.add< libcasm_fe::TypeInferencePass >();
         pm.add< libcasm_fe::ConsistencyCheckPass >();
+        pm.add< libcasm_fe::FrameSizeDeterminationPass >();
         pm.add< libcasm_fe::NumericExecutionPass >();
 
         pm.setDefaultPass< libcasm_fe::NumericExecutionPass >();


### PR DESCRIPTION
This pass is only required when executing the specification and thus only
registered in `textDocument_execute`.

https://github.com/casm-lang/libcasm-fe/pull/88